### PR TITLE
Custom files support

### DIFF
--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -171,7 +171,12 @@ func Test_PGinsertFiles(t *testing.T) {
 		chartID   string = repoName + "/wordpress"
 		filesID   string = chartID + "-2.1.3"
 	)
-	files := models.ChartFiles{ID: filesID, Readme: "foo", Values: "bar", Repo: &models.Repo{Namespace: namespace, Name: repoName}}
+
+	customFilesMap := make(map[string]string)
+    customFilesMap["install.schema.json"] = "{}"
+    customFilesMap["install.uiSchema.json"] = "{}"
+
+	files := models.ChartFiles{ID: filesID, Readme: "foo", Values: "bar", Repo: &models.Repo{Namespace: namespace, Name: repoName}, CustomFiles: customFilesMap}
 	mock.ExpectQuery(`INSERT INTO files \(chart_id, repo_name, repo_namespace, chart_files_ID, info\)*`).
 		WithArgs(chartID, repoName, namespace, filesID, files).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow("3"))

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -27,11 +27,11 @@ import (
 )
 
 var syncCmd = &cobra.Command{
-	Use:   "sync [REPO NAME] [REPO URL] [REPO TYPE]",
+	Use:   "sync [REPO NAME] [REPO URL] [REPO TYPE] [CUSTOM FILES DIRECTORY]",
 	Short: "add a new chart repository, and resync its charts periodically",
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 3 {
-			logrus.Info("Need exactly two arguments: [REPO NAME] [REPO URL] [REPO TYPE]")
+		if len(args) < 3 {
+			logrus.Info("Need at least three arguments: [REPO NAME] [REPO URL] [REPO TYPE]")
 			cmd.Help()
 			return
 		}
@@ -83,9 +83,15 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 
+        customFilesDirectoryName := ""
+        if len(args) == 4 {
+            customFilesDirectoryName = args[4]
+        }
+
+
 		// Fetch and store chart icons
 		fImporter := fileImporter{manager}
-		fImporter.fetchFiles(charts, repoIface)
+		fImporter.fetchFiles(charts, repoIface, customFilesDirectoryName)
 
 		// Update cache in the database
 		if err = manager.UpdateLastCheck(repo.Namespace, repo.Name, checksum, time.Now()); err != nil {

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -85,7 +85,7 @@ var syncCmd = &cobra.Command{
 
         customFilesDirectoryName := ""
         if len(args) == 4 {
-            customFilesDirectoryName = args[4]
+            customFilesDirectoryName = args[3]
         }
 
 

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -198,8 +198,7 @@ func (r *HelmRepo) FetchAllFilesFromDirectory(name string, cv models.ChartVersio
 	// get last part of the name
 	// ie., "foo/bar" should return "bar"
 	fixedName := path.Base(decodedName)
-	directoryPath := fixedName + directoryName
-
+	directoryPath := fixedName +"/"+ directoryName
 
 	filesInDirectory, err := extractDirectoryFilesFromTarball(directoryPath, tarf)
 	if err != nil {
@@ -520,6 +519,7 @@ func extractDirectoryFilesFromTarball(directoryPath string, tarf *tar.Reader) (m
         if strings.HasPrefix(header.Name, directoryPath) {
             var b bytes.Buffer
             io.Copy(&b, tarf)
+            //TODO headear.name take only the files part
             ret[header.Name] = string(b.Bytes())
 
         }

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -198,6 +198,7 @@ func (r *HelmRepo) FetchAllFilesFromDirectory(name string, cv models.ChartVersio
 	// get last part of the name
 	// ie., "foo/bar" should return "bar"
 	fixedName := path.Base(decodedName)
+
 	directoryPath := fixedName +"/"+ directoryName
 
 	filesInDirectory, err := extractDirectoryFilesFromTarball(directoryPath, tarf)
@@ -516,11 +517,19 @@ func extractDirectoryFilesFromTarball(directoryPath string, tarf *tar.Reader) (m
             return ret, err
         }
 
-        if strings.HasPrefix(header.Name, directoryPath) {
+        var fixedDirectoryPath string
+
+        if strings.HasSuffix(directoryPath,"/") == true {
+            fixedDirectoryPath = directoryPath
+	    } else {
+		    fixedDirectoryPath = directoryPath + "/"
+	    }
+
+
+        if strings.HasPrefix(header.Name, fixedDirectoryPath) {
             var b bytes.Buffer
             io.Copy(&b, tarf)
-            //TODO headear.name take only the files part
-            ret[header.Name] = string(b.Bytes())
+            ret[strings.ReplaceAll(header.Name,fixedDirectoryPath,"")] = string(b.Bytes())
 
         }
 

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -390,6 +390,26 @@ func Test_extractFilesFromTarball(t *testing.T) {
 	})
 }
 
+
+func Test_extractDirectoryFilesFromTarball(t *testing.T) {
+
+	t.Run("extract files from dir", func(t *testing.T) {
+		var b bytes.Buffer
+		tFiles := []tarballFile{{"CustomFiles/file.txt", "best file ever"}, {"file2.txt", "worst file ever"}}
+		createTestTarball(&b, tFiles)
+		r := bytes.NewReader(b.Bytes())
+		tarf := tar.NewReader(r)
+		files, err := extractDirectoryFilesFromTarball("CustomFiles", tarf)
+		assert.NoErr(t, err)
+		assert.Equal(t, len(files), 1, "matches")
+		assert.Equal(t, files["CustomFiles/file.txt"], "best file ever", "matches file content")
+
+	})
+
+}
+
+
+
 type tarballFile struct {
 	Name, Body string
 }

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -402,7 +402,7 @@ func Test_extractDirectoryFilesFromTarball(t *testing.T) {
 		files, err := extractDirectoryFilesFromTarball("CustomFiles", tarf)
 		assert.NoErr(t, err)
 		assert.Equal(t, len(files), 1, "matches")
-		assert.Equal(t, files["CustomFiles/file.txt"], "best file ever", "matches file content")
+		assert.Equal(t, files["file.txt"], "best file ever", "matches file content")
 
 	})
 

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -583,6 +583,12 @@ func (r *fakeRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]s
 	}, nil
 }
 
+func (r *fakeRepo) FetchAllFilesFromDirectory(name string, cv models.ChartVersion, directoryName string) (map[string]string, error){
+    // TBD
+    return r.chartFiles.CustomFiles, nil
+}
+
+
 func Test_fetchAndImportFiles(t *testing.T) {
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
 	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", URL: "http://testrepo.com"}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -595,7 +595,12 @@ func (r *fakeRepo) Charts() ([]models.Chart, error) {
 	return r.charts, nil
 }
 
-func (r *fakeRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]string, error) {
+func (r *fakeRepo)  FetchTarChart(name string, cv models.ChartVersion) (*tar.Reader, error) {
+    // TBD
+    return nil, nil
+}
+
+func (r *fakeRepo) FetchFiles(name string, cv models.ChartVersion, tarf *tar.Reader) (map[string]string, error) {
 	return map[string]string{
 		values: r.chartFiles.Values,
 		readme: r.chartFiles.Readme,
@@ -603,7 +608,7 @@ func (r *fakeRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]s
 	}, nil
 }
 
-func (r *fakeRepo) FetchAllFilesFromDirectory(name string, cv models.ChartVersion, directoryName string) (map[string]string, error){
+func (r *fakeRepo) FetchAllFilesFromDirectory(name string, cv models.ChartVersion, directoryName string, tarf *tar.Reader) (map[string]string, error){
     // TBD
     return r.chartFiles.CustomFiles, nil
 }

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -54,6 +54,7 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.schema.json").Handler(WithParams(getChartVersionSchema))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/custominfo/{filename}").Handler(WithParams(getChartVersionCustomInfo))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/logo").Handler(WithParams(getChartIcon))
 
 	// Leave icon on the non-cluster aware as it is used from a link in the db data :/

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -96,6 +96,7 @@ type ChartFiles struct {
 	Schema string
 	Repo   *Repo
 	Digest string
+	CustomFiles map[string]string `json:"custom_files" bson:"-"`
 }
 
 // Allow to convert ChartFiles to a sql JSON

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -99,6 +99,10 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 	config.BearerToken = userToken
 	config.BearerTokenFile = ""
 
+	if cluster == "" {
+		cluster = "default"
+	}
+
 	clusterConfig, ok := clustersConfig.Clusters[cluster]
 	if !ok {
 		return nil, fmt.Errorf("cluster %q has no configuration", cluster)


### PR DESCRIPTION
### Description of the change

This PR adds the capabilities to store, inside the asset syncher DB, the content of custom files that are in a user defined directory inside the helm chart tar.
Moreover, it adds the capabilities to retrieve the file's contents by means of the following Rest API

GET "/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/custominfo/{filename}"
 
### Benefits

The primary goal is:
- to give the possibility to store inside kubeapps DB other files in addition to schema and values files
- to give the possibility to use kubeapps REST API layer to retrieve it

### Possible drawbacks

No drawbacks

### Applicable issues


### Additional information

